### PR TITLE
Add support for the PhpStorm Mac scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ placing a link of the following kind in the markup:
     <?php
     $file = "/path/to/filename.php";
     $line = 35;
-    print "<a href="phpstorm://open?url=file://$file&line=$line">Open with PhpStorm</a>";
+    print "<a href=\"phpstorm://open?url=file://$file&line=$line\">Open with PhpStorm</a>";
     // Alternate Syntax to match PhpStorm 8 for the Macintosh
-    print "<a href="phpstorm://open?file=$file&line=$line">Open with PhpStorm</a>";
+    print "<a href=\"phpstorm://open?file=$file&line=$line\">Open with PhpStorm</a>";
     ?>
 
 ## Command-line usage

--- a/README.md
+++ b/README.md
@@ -18,13 +18,23 @@ placing a link of the following kind in the markup:
     $file = "/path/to/filename.php";
     $line = 35;
     print "<a href="phpstorm://open?url=file://$file&line=$line">Open with PhpStorm</a>";
+    // Alternate Syntax to match PhpStorm 8 for the Macintosh
+    print "<a href="phpstorm://open?file=$file&line=$line">Open with PhpStorm</a>";
     ?>
 
-## Commandline usage
+## Command-line usage
 
     FILE="/path/to/filename.php"
     LINE=35
     ./phpstorm-url-handler "phpstorm://open?url=file://${FILE}&line=${LINE}"
+
+
+This alternative syntax matches the format used by
+PhpStorm 8 for the Macintosh for cross-platform compatibility.
+
+    FILE="/path/to/filename.php"
+    LINE=35
+    ./phpstorm-url-handler "phpstorm://open?file=${FILE}&line=${LINE}"
 
 This script is used in the ARCH linux package to be found at  
 phpstorm-url-handler https://aur.archlinux.org/packages/phpstorm-url-handler/

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ placing a link of the following kind in the markup:
     <?php
     $file = "/path/to/filename.php";
     $line = 35;
-    print "<a href=\"phpstorm://open?url=file://$file&line=$line\">Open with PhpStorm</a>";
+    print "<a href='phpstorm://open?url=file://$file&line=$line'>Open with PhpStorm</a>";
     // Alternate Syntax to match PhpStorm 8 for the Macintosh
-    print "<a href=\"phpstorm://open?file=$file&line=$line\">Open with PhpStorm</a>";
+    print "<a href='phpstorm://open?file=$file&line=$line'>Open with PhpStorm</a>";
     ?>
 
 ## Command-line usage

--- a/phpstorm-url-handler
+++ b/phpstorm-url-handler
@@ -2,16 +2,18 @@
 
 # PhpStorm URL Handler
 # phpstorm://open?url=file://@file&line=@line
+# phpstorm://open?file=@file&line=@line
 #
 # @license GPL
 # @author Stefan Auditor <stefan.auditor@erdfisch.de>
 
 arg=${1}
+pattern=".*file(:\/\/|\=)(.*)&line=(.*)"
 
 # Get the file path.
-file=$(echo "${arg}" | sed -r 's/.*file:\/\/(.*)&line=.*/\1/')
+file=$(echo "${arg}" | sed -r "s/${pattern}/\2/")
 
 # Get the line number.
-line=$(echo "${arg}" | sed -r 's/.*file:\/\/.*&line=(.*)/\1/')
+line=$(echo "${arg}" | sed -r "s/${pattern}/\3/")
 
 /usr/bin/env phpstorm --line "${line}" "${file}"

--- a/phpstorm-url-handler
+++ b/phpstorm-url-handler
@@ -8,12 +8,12 @@
 # @author Stefan Auditor <stefan.auditor@erdfisch.de>
 
 arg=${1}
-pattern=".*file(:\/\/|\=)(.*)&line=(.*)"
+pattern=".*file(?::\/\/|\=)(.*)&line=(.*)"
 
 # Get the file path.
-file=$(echo "${arg}" | sed -r "s/${pattern}/\2/")
+file=$(echo "${arg}" | sed -r "s/${pattern}/\1/")
 
 # Get the line number.
-line=$(echo "${arg}" | sed -r "s/${pattern}/\3/")
+line=$(echo "${arg}" | sed -r "s/${pattern}/\2/")
 
 /usr/bin/env phpstorm --line "${line}" "${file}"

--- a/phpstorm-url-handler.desktop
+++ b/phpstorm-url-handler.desktop
@@ -2,8 +2,7 @@
 Version=1.0
 Type=Application
 Name=PhpStorm URL Handler
-Comment=Handle URL Scheme phpstorm://open?url=file://@file&line=@line
-# or Alternate URL Scheme phpstorm://open?file=@file&line=@line
+Comment=Handle URL Scheme phpstorm://open?url=file://@file&line=@line and phpstorm://open?file=@file&line=@line
 Icon=phpstorm
 NoDisplay=true
 Categories=TextEditor;Utility;

--- a/phpstorm-url-handler.desktop
+++ b/phpstorm-url-handler.desktop
@@ -3,6 +3,7 @@ Version=1.0
 Type=Application
 Name=PhpStorm URL Handler
 Comment=Handle URL Scheme phpstorm://open?url=file://@file&line=@line
+# or Alternate URL Scheme phpstorm://open?file=@file&line=@line
 Icon=phpstorm
 NoDisplay=true
 Categories=TextEditor;Utility;


### PR DESCRIPTION
PhpStorm 8 (Mac) provided native support for the "phpstorm:" protocol.  However, they implemented a different format for the the URL.

PhpStorm Mac uses: ``phpstorm://open?file=@file&line=@line``
This handler uses ``phpstorm://open?url=file://@file&line=@line``

symfony/symfony#21712 is going to change the default format to be the Macintosh format.

This pull request contains the necessary modifications to support both formats simultaneously.  This would standardize the system so that you would not need two different configurations if you are working on different platforms (i.e. Linux vs Mac) 