### PR TITLE
Added update-desktop-database command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Specification for use in Gnome and KDE desktop environments.
 
     cp phpstorm-url-handler /usr/bin/phpstorm-url-handler
     desktop-file-install phpstorm-url-handler.desktop
+    update-desktop-database
 
 ## Usage
 


### PR DESCRIPTION
I added the `update-desktop-database` to the installation process.
I needed to run this to (obviously) `update` the `desktop database` before using the urls.