### PR TITLE
urldecode fix and path mapping (for docker/devilbox)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ placing a link of the following kind in the markup:
     print "<a href='phpstorm://open?file=$file&line=$line'>Open with PhpStorm</a>";
     ?>
 
+Added in ability to path map to local files from docker/devilbox.
+
+Edit phpstorm-url-handler file, find the following lines:
+find="/shared/httpd/"
+replace="/home/michael/public_html/";
+
+change the content of the find variable with the path the files are located on docker/devilbox, and change the content of the replace variable with the path to the local files.
+
 ## Command-line usage
 
     FILE="/path/to/filename.php"

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ placing a link of the following kind in the markup:
 Added in ability to path map to local files from docker/devilbox.
 
 Edit phpstorm-url-handler file, find the following lines:
-find="/shared/httpd/"
-replace="/home/michael/public_html/";
+
+    find="/shared/httpd/"
+    
+    replace="/home/michael/public_html/";
 
 change the content of the find variable with the path the files are located on docker/devilbox, and change the content of the replace variable with the path to the local files.
 

--- a/phpstorm-url-handler
+++ b/phpstorm-url-handler
@@ -10,13 +10,16 @@
 urldecode() { : "${*//+/ }"; echo -e "${_//%/\\x}"; }
 arg=$(urldecode "${1}")
 pattern=".*file(:\/\/|\=)(.*)&line=(.*)"
+find="/shared/httpd/"
+replace="/home/michael/public_html/";
+
 
 # Get the file path.
 file=$(echo "${arg}" | sed -r "s/${pattern}/\2/")
-
+file=$(echo "${file/${find}/${replace}}")
 # Get the line number.
 line=$(echo "${arg}" | sed -r "s/${pattern}/\3/")
-
+ 
 # Check if phpstorm|pstorm command exist.
 if type phpstorm > /dev/null; then
     /usr/bin/env phpstorm --line "${line}" "${file}"

--- a/phpstorm-url-handler
+++ b/phpstorm-url-handler
@@ -7,7 +7,8 @@
 # @license GPL
 # @author Stefan Auditor <stefan.auditor@erdfisch.de>
 
-arg=${1}
+urldecode() { : "${*//+/ }"; echo -e "${_//%/\\x}"; }
+arg=$(urldecode "${1}")
 pattern=".*file(:\/\/|\=)(.*)&line=(.*)"
 
 # Get the file path.


### PR DESCRIPTION
the link in linux gets url encoded, this will decode it and allow it to work.

also has a path mapping, so you can replace a docker/devilbox path to map to the location on your drive. 