### PR TITLE
Search window name by file basename

### DIFF
--- a/phpstorm-url-handler
+++ b/phpstorm-url-handler
@@ -28,7 +28,8 @@ elif type pstorm > /dev/null; then
 fi
 
 if type wmctrl > /dev/null; then
-    /usr/bin/env wmctrl -i -a $(wmctrl -l | grep "${file}" | tail -n 1 | cut -d ' ' -f1)
+    filename=$(basename "$file")
+    /usr/bin/env wmctrl -i -a $(wmctrl -l | grep "${filename}" | tail -n 1 | cut -d ' ' -f1)
 fi
 
 exit 0


### PR DESCRIPTION
Window name content only basename file and wmctrl not working....

![image](https://user-images.githubusercontent.com/1577055/153211603-66355841-0477-4f47-afa8-884a2cac00c4.png)
